### PR TITLE
Add missing Threads package requirement in CMake configuration

### DIFF
--- a/cmake/sdu_controllersConfig.cmake
+++ b/cmake/sdu_controllersConfig.cmake
@@ -2,6 +2,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/sdu_controllers-config.cmake")
 set(SDU_CONTROLLERS_LIBRARIES sdu_controllers::sdu_controllers)
 
 # Required dependencies
+find_package(Threads REQUIRED)
 find_package(yaml-cpp CONFIG REQUIRED)
 find_package(Eigen3 REQUIRED NO_MODULE)
 


### PR DESCRIPTION
This pull request makes a small change to the `cmake/sdu_controllersConfig.cmake` file to ensure that thread support is available during the build process.

* Added a required dependency on the `Threads` package by including `find_package(Threads REQUIRED)`.